### PR TITLE
Delete profile before creating it in test runner

### DIFF
--- a/src/nih_wayfinding/test/spec/profiles/profiles-service.spec.js
+++ b/src/nih_wayfinding/test/spec/profiles/profiles-service.spec.js
@@ -11,6 +11,7 @@ describe('nih.profiles: ProfileService', function () {
     // Initialize the controller and a mock scope
     beforeEach(inject(function (_ProfileService_) {
         ProfileService = _ProfileService_;
+        ProfileService.deleteProfile(testUserName);
         profile = ProfileService.createProfile(testUserName);
     }));
 


### PR DESCRIPTION
My tests ended up in a broken state somehow where a
createProfile(testUserName) was stuck in phantomjs
local storage. Calling deleteProfile before createProfile
in the beforeEach ensures that the createProfile call
will be successful.
