### PR TITLE
Submit typeahead directly to LocationController.search onSelect

### DIFF
--- a/src/nih_wayfinding/app/scripts/views/locations/locations-controller.js
+++ b/src/nih_wayfinding/app/scripts/views/locations/locations-controller.js
@@ -37,8 +37,8 @@
             }
         }
 
-        function search() {
-            Geocoder.search(ctl.searchText).then(onGeocoderResponse);
+        function search(searchText) {
+            Geocoder.search(searchText).then(onGeocoderResponse);
         }
 
         function loadRoute(feature) {

--- a/src/nih_wayfinding/app/scripts/views/locations/locations-partial.html
+++ b/src/nih_wayfinding/app/scripts/views/locations/locations-partial.html
@@ -24,10 +24,9 @@
                    type="text"
                    placeholder="Search Chicago..."
                    ng-model="locations.searchText"
-                   ng-submit="locations.search()"
-                   ng-keyup="$event.keyCode === 13 ? locations.search() : null"
                    ng-focus="locations.findAddressExpanded = true"
                    typeahead="location for location in locations.suggest($viewValue)"
+                   typeahead-on-select="locations.search($item)"
                    typeahead-wait-ms="300"
                    typeahead-min-length="3" />
             <button type="button" class="close" aria-label="Close"


### PR DESCRIPTION
The ng-submit and ng-keyup were messing with the default submit implementation of the typeahead directive. Removed in favor of using the built-in typeahead-on-select parameter, which is called on enter key or clicking the autocompleted list.
