### PR TITLE
Add notification delay option and use in geolocation alert

### DIFF
--- a/src/nih_wayfinding/app/scripts/notifications/notifications-service.js
+++ b/src/nih_wayfinding/app/scripts/notifications/notifications-service.js
@@ -3,7 +3,9 @@
     'use strict';
 
     /* ngInject */
-    function Notifications($rootScope) {
+    function Notifications($rootScope, $timeout) {
+
+        var timeoutId = null;
 
         var module = {
             hide: hide,
@@ -17,6 +19,10 @@
          * @return Broadcasts nih.notifications.hide on $rootScope
          */
         function hide() {
+            if (timeoutId) {
+                $timeout.cancel(timeoutId);
+                timeoutId = null;
+            }
             $rootScope.$broadcast('nih.notifications.hide');
         }
 
@@ -28,12 +34,15 @@
         function show(options) {
             var defaults = {
                 timeout: 0,
+                delay: 0,
                 closeButton: true,
                 text: '',
                 imageClass: 'glyphicon-warning-sign'
             };
             var opts = angular.extend({}, defaults, options);
-            $rootScope.$broadcast('nih.notifications.show', opts);
+            timeoutId = $timeout(function () {
+                $rootScope.$broadcast('nih.notifications.show', opts);
+            }, opts.delay, false);
         }
     }
 

--- a/src/nih_wayfinding/app/scripts/views/routing/overview/overview-controller.js
+++ b/src/nih_wayfinding/app/scripts/views/routing/overview/overview-controller.js
@@ -9,11 +9,12 @@
 */
 
     /* ngInject */
-    function OverviewController($scope, $stateParams, $q, $geolocation, leafletData,
-                                Config, Directions, Map, MapControl, MapStyle, NavbarConfig, 
+    function OverviewController($q, $scope, $stateParams, $timeout, $geolocation, leafletData,
+                                Config, Directions, Map, MapControl, MapStyle, NavbarConfig,
                                 Notifications) {
         var ctl = this;
         var defaultNonZeroWalkTime = 30;
+        var geolocationAlertDelay = 400;
         var directionsOptions = {
             walkTimeMins: 0
         };
@@ -65,7 +66,8 @@
             } else {
                 Notifications.show({
                     text: 'Click \'Allow\' in your browser\'s location prompt to request your route.',
-                    imageClass: 'glyphicon-info-sign'
+                    imageClass: 'glyphicon-info-sign',
+                    delay: geolocationAlertDelay
                 });
                 $geolocation.getCurrentPosition({}).then(function (position) {
                     Notifications.hide();

--- a/src/nih_wayfinding/test/spec/notifications/notifications-service.spec.js
+++ b/src/nih_wayfinding/test/spec/notifications/notifications-service.spec.js
@@ -6,29 +6,59 @@ describe('nih.notifications: Notifications', function () {
     beforeEach(module('nih.notifications'));
 
     var rootScope;
+    var timeout;
     var Notifications;
     var testAlert = {
         text: 'Test',
         timeout: 300,
+        delay: 0,
         closeButton: false,
         imageClass: 'glyphicon-warning-sign'
     };
 
     // Initialize the controller and a mock scope
-    beforeEach(inject(function ($rootScope, _Notifications_) {
+    beforeEach(inject(function ($rootScope, $timeout, _Notifications_) {
         rootScope = $rootScope;
+        timeout = $timeout;
         Notifications = _Notifications_;
     }));
 
     it('should trigger nih.notifications.show on Notifications.show', function () {
         spyOn(rootScope, '$broadcast');
         Notifications.show(testAlert);
+        timeout.flush(1);
         expect(rootScope.$broadcast).toHaveBeenCalledWith('nih.notifications.show', testAlert);
     });
 
     it('should trigger nih.notifications.hide on Notifications.hide', function () {
         spyOn(rootScope, '$broadcast');
         Notifications.hide();
+        expect(rootScope.$broadcast).toHaveBeenCalledWith('nih.notifications.hide');
+    });
+
+    it('should trigger nih.notifications.show after a delay', function (){
+        var alertDelay = 300;
+        var delayedAlert = angular.extend({}, testAlert, {delay: alertDelay});
+        spyOn(rootScope, '$broadcast');
+        Notifications.show(delayedAlert);
+        timeout.flush(alertDelay / 2);
+        rootScope.$digest();
+        expect(rootScope.$broadcast).not.toHaveBeenCalledWith('nih.notifications.show', jasmine.any(Object));
+        timeout.flush(alertDelay);
+        rootScope.$digest();
+        expect(rootScope.$broadcast).toHaveBeenCalledWith('nih.notifications.show', jasmine.any(Object));
+    });
+
+    it('should not call nih.notifications.show if hide is called before delay expires', function () {
+        var alertDelay = 300;
+        var delayedAlert = angular.extend({}, testAlert, {delay: alertDelay});
+        spyOn(rootScope, '$broadcast');
+        Notifications.show(delayedAlert);
+        timeout.flush(alertDelay / 2);
+        rootScope.$digest();
+        Notifications.hide();
+        timeout.flush(alertDelay);
+        rootScope.$digest();
         expect(rootScope.$broadcast).toHaveBeenCalledWith('nih.notifications.hide');
     });
 });

--- a/src/nih_wayfinding/test/spec/views/navbar/navbar-controller.spec.js
+++ b/src/nih_wayfinding/test/spec/views/navbar/navbar-controller.spec.js
@@ -45,6 +45,7 @@ describe('nih.views.navbar: NavbarController', function () {
     var testText = 'test';
     expect(NavbarController.alertHeight).toEqual(0);
     Notifications.show({text: testText});
+    timeout.flush(1);
     rootScope.$digest();
     expect(NavbarController.alert.text).toEqual(testText);
     expect(NavbarController.alertHeight).toBeGreaterThan(0);


### PR DESCRIPTION
The geolocation API varies widely on how long it takes
to respond. Seems to be relatively quick on safari/firefox
assuming a location was already found, slower on some chromes.

Delaying the notification a bit is a relatively quick solution
to fix the common case where the geolocation very quickly locks
when previously allowed, but not immediately.

Other solutions would be more extensive, such as first making
a getCurrentLocation call with timeout: 0, maximumAge: Infinity
to get a cached position. This could be used to determine
whether the user has allowed geolocation. Once determined,
the actual getCurrentPosition call could be made.
