### PR TITLE
Switch to Google Streets for default base layer

### DIFF
--- a/src/nih_wayfinding/app/index.html
+++ b/src/nih_wayfinding/app/index.html
@@ -66,6 +66,7 @@
        ga('send', 'pageview');
     </script>
 
+    <script src="http://maps.google.com/maps/api/js?v=3&sensor=false"></script>
     <!-- build:js(.) scripts/oldieshim.js -->
     <!--[if lt IE 9]>
     <script src="bower_components/es5-shim/es5-shim.js"></script>
@@ -91,6 +92,7 @@
     <script src="bower_components/angular-leaflet-directive/dist/angular-leaflet-directive.js"></script>
     <script src="bower_components/Leaflet.encoded/Polyline.encoded.js"></script>
     <script src="bower_components/turf/turf.min.js"></script>
+    <script src="bower_components/leaflet-plugins/layer/tile/Google.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/src/nih_wayfinding/app/scripts/config.js
+++ b/src/nih_wayfinding/app/scripts/config.js
@@ -16,6 +16,14 @@
             }
         },
         baseLayers: {
+            googleStreets: {
+                name: 'Google Streets',
+                type: 'google',
+                layerType: 'ROADMAP'
+            },
+            // TODO: This needs to be removed once we start displaying Google Places data, but
+            // for development it's good to have as a comparison since the Leaflet plugin enabling
+            // Google layers may not always work perfectly.
             stamentonerlite: {
                 name: 'Stamen Toner Lite',
                 type: 'xyz',

--- a/src/nih_wayfinding/bower.json
+++ b/src/nih_wayfinding/bower.json
@@ -17,7 +17,8 @@
     "angular-local-storage": "0.1.5",
     "angular-leaflet-directive": "~0.7.10",
     "Leaflet.encoded": "~0.0.5",
-    "turf": "~1.3.0"
+    "turf": "~1.3.0",
+    "leaflet-plugins": "~1.2.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.0",


### PR DESCRIPTION
This is so we can use data from the Google Places API, which must be
displayed on a Google map. Google's Places API is the most complete
places API that can be used directly from Javascript without
authentication. If this application moves beyond the prototype stage, we
will likely choose a different places provider.

Using an API like Foursquare, CityGrid, Factual, etc., would require us to set up a proxy to the API to avoid exposing the app's API key to client-side Javascript, while Google Places can be called from Javascript without keys. Google's Places API is more complete than OpenStreetMap, which only has churches and some schools for the area we're concerned with.
