### PR TITLE
Use a *less* specific version for openjdk

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,7 +4,7 @@ developing_or_testing: "'development' in group_names or 'test' in group_names"
 not_developing: "'development' not in group_names"
 not_testing: "'test' not in group_names"
 
-java_version: "7u7*"
+java_version: "7u75-*"
 
 python_version: "2.7.*"
 pip_version: "1.*"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,7 +4,7 @@ developing_or_testing: "'development' in group_names or 'test' in group_names"
 not_developing: "'development' not in group_names"
 not_testing: "'test' not in group_names"
 
-java_version: "7u71*"
+java_version: "7u7*"
 
 python_version: "2.7.*"
 pip_version: "1.*"


### PR DESCRIPTION
Using too specific a version will cause breakage when a package is removed. 7u71\* didn't correspond to any packages and apt repos are already on 7u75.
