### PR TITLE
Use oracle java 8.

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,7 +4,9 @@ developing_or_testing: "'development' in group_names or 'test' in group_names"
 not_developing: "'development' not in group_names"
 not_testing: "'test' not in group_names"
 
-java_version: "7u75-*"
+oracle_java_version: "8"
+oracle_java_package_version: "8u31*"
+oracle_java_accept_license_agreement: True
 
 python_version: "2.7.*"
 pip_version: "1.*"

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,9 +1,9 @@
 azavea.git,0.1.0
-azavea.java,0.1.1
+azavea.oracle-java,0.1.0
 azavea.nginx,0.2.0
 azavea.nodejs,0.2.0
 azavea.ntp,0.1.0
-azavea.opentripplanner,0.2.1
+azavea.opentripplanner,0.2.3
 azavea.pgweb,0.1.1
 azavea.pip,0.1.0
 azavea.postgis,0.1.2


### PR DESCRIPTION
Closes #60.

To switch java versions without destroying the otp VM before re-provisioning, it may be necessary to ssh into the otp VM and run:

``` bash
sudo update-alternatives --config java
```

then select the option for `java-8-oracle`.
