### PR TITLE
Rename surface type variable.

### DIFF
--- a/src/nih_wayfinding/app/scripts/profiles/profile-preference-options.js
+++ b/src/nih_wayfinding/app/scripts/profiles/profile-preference-options.js
@@ -26,7 +26,7 @@
                 value: 'cane'
             }],
 
-            steepTerrainOpts: [{
+            surfaceTypeComfortOpts: [{
                 text: 'Not very',
                 value: 0.1
             }, {

--- a/src/nih_wayfinding/app/scripts/routing/directions-service.js
+++ b/src/nih_wayfinding/app/scripts/routing/directions-service.js
@@ -103,10 +103,7 @@
 
             params.walkSpeed = preferences.speed;
 
-            // TODO: OTP currently only can ban sloped edges; no option to weight more heavily
-            if (preferences.steepTerrainComfort < 0.5) {
-                params.allowUnevenSurfaces = false;
-            }
+            params.surfaceComfort = preferences.surfaceTypeComfort;
 
             if (preferences.assistanceRequired) {
                 // set "walk" speed for powered vs manual wheelchairs
@@ -272,11 +269,14 @@
 
                 var warnings = [];
                 var features = [];
-                if (step.unevenSurfaces) {
-                    warnings.push('This street has uneven surfaces.');
+                if (step.crossSlope) {
+                    warnings.push('This street has a cross slope.');
                 }
                 if (step.maxSlope > Config.warningMinimumGrade) {
                     warnings.push('This street has steep sections.');
+                }
+                if (step.surface !== 'Concrete') {
+                    warnings.push('Street surface is ' + step.surface);
                 }
                 if (step.aesthetics) {
                     // TODO: what should the message here be?

--- a/src/nih_wayfinding/app/scripts/views/profile/new-profile/new-profile-controller.js
+++ b/src/nih_wayfinding/app/scripts/views/profile/new-profile/new-profile-controller.js
@@ -19,7 +19,7 @@
             ctl.setUsingAssistance = setUsingAssistance;
             ctl.assistanceTypeDialog = false;
             ctl.setAssistanceType = setAssistanceType;
-            ctl.setSteepTerrainComfort = setSteepTerrainComfort;
+            ctl.setSurfaceTypeComfort = setSurfaceTypeComfort;
             ctl.setSpeed = setSpeed;
             ctl.setBusyness = setBusyness;
             ctl.setRestFrequency = setRestFrequency;
@@ -54,10 +54,10 @@
         }
 
         /**
-         * Set private var for profile steepTerrainComfort level.
+         * Set private var for profile surfaceTypeComfort level.
          */
-        function setSteepTerrainComfort(comfort) {
-            ctl.newUser.setPreference('steepTerrainComfort', comfort.value);
+        function setSurfaceTypeComfort(comfort) {
+            ctl.newUser.setPreference('surfaceTypeComfort', comfort.value);
             setStep(4);
         }
 

--- a/src/nih_wayfinding/app/scripts/views/profile/new-profile/new-profile-partial.html
+++ b/src/nih_wayfinding/app/scripts/views/profile/new-profile/new-profile-partial.html
@@ -42,8 +42,8 @@
                     <h2>How comfortable are you on uneven surfaces?</h2>
                     <div class="btn-group btn-group-justified" role="group"
                         aria-label="Select comfort on uneven terrain">
-                        <nih-options-grid options="newprofile.preferenceOpts.steepTerrainOpts"
-                                          on-option-clicked="newprofile.setSteepTerrainComfort(option)">
+                        <nih-options-grid options="newprofile.preferenceOpts.surfaceTypeComfortOpts"
+                                          on-option-clicked="newprofile.setSurfaceTypeComfort(option)">
                         </nih-options-grid>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #99.
Also adds warning for non-concrete surfaces.

The added surface type query param and return value are in azavea/OpenTripPlanner#17.
