### PR TITLE
Move from minor version 5-3 to 6-1

### DIFF
--- a/deployment/ansible/roles/nih-wayfinding.app/meta/main.yml
+++ b/deployment/ansible/roles/nih-wayfinding.app/meta/main.yml
@@ -3,6 +3,6 @@ dependencies:
   - { role: "azavea.git" }
   - { role: "azavea.nginx", nginx_delete_default_site: True }
   - { role: "azavea.pip" }
-  - { role: "azavea.postgresql-support" }
+  - { role: "azavea.postgresql-support", postgresql_support_libpq_version: "9.3.6*.pgdg12.04+1"}
   - { role: "azavea.python", python_development: True }
   - { role: "nih-wayfinding.nodejs" }


### PR DESCRIPTION
This fixes a provisioning error around not being able to find the previous version of the package
