### PR TITLE
Fix OTP params being overridden; use last returned plan

### DIFF
--- a/src/nih_wayfinding/app/scripts/mapping/map-route-service.js
+++ b/src/nih_wayfinding/app/scripts/mapping/map-route-service.js
@@ -96,7 +96,7 @@
                 deferred.reject(msg);
             }
 
-            Directions.get(origin, destination, options).then(setGeojson, failure);
+            Directions.get(origin, destination).then(setGeojson, failure);
             return deferred.promise;
         }
     }

--- a/src/nih_wayfinding/app/scripts/routing/directions-service.js
+++ b/src/nih_wayfinding/app/scripts/routing/directions-service.js
@@ -31,7 +31,7 @@
          * @param options {object}
          * // TODO: Document options object
          */
-        function get(origin, destination, options) {
+        function get(origin, destination) {
             var dfd = $q.defer();
             if (!(_.isArray(origin) && origin.length >= 2)) {
                 dfd.reject({ msg: 'Invalid origin parameter' });
@@ -42,7 +42,7 @@
                 return dfd.promise;
             }
             var otpRequestParams = getRequestParams();
-            var params = angular.extend({}, otpRequestParams, options);
+            var params = angular.extend({}, otpRequestParams);
             // Swap, OTP request uses [lat,lon]
             params.fromPlace = [origin[1], origin[0]].join(',');
             params.toPlace = [destination[1], destination[0]].join(',');
@@ -220,7 +220,7 @@
         function transformOtpToGeoJson(otpResponse) {
 
             var itineraries = otpResponse.plan.itineraries;
-            var itinerary = itineraries[0];
+            var itinerary = itineraries[itineraries.length - 1];
             var lineStrings = [];
             currentRouteSummary.distanceMeters = itinerary.walkDistance;
             currentRouteSummary.timeMinutes = itinerary.duration / 60;

--- a/src/nih_wayfinding/app/scripts/views/routing/overview/overview-controller.js
+++ b/src/nih_wayfinding/app/scripts/views/routing/overview/overview-controller.js
@@ -42,12 +42,8 @@
         }
 
         function getDirections(data) {
-            var options = angular.extend({}, directionsOptions, {
-                wheelchair: !!(currentUser.preferences.wheelchairRequired),
-            });
-
             Navigation.setDestination(data.destination);
-            MapRoute.mapRoute(data.origin, data.destination, options).then(function(mappedRoute) {
+            MapRoute.mapRoute(data.origin, data.destination).then(function(mappedRoute) {
                 angular.extend(ctl.map, mappedRoute);
                 ctl.summary = angular.extend(ctl.summary, Directions.getRouteSummary());
             });

--- a/src/nih_wayfinding/test/spec/views/routing/overview/overview-controller.spec.js
+++ b/src/nih_wayfinding/test/spec/views/routing/overview/overview-controller.spec.js
@@ -41,7 +41,7 @@ describe('nih.views.routing: OverviewController', function () {
     }
     function mockMapRouteService($q) {
         return {
-            mapRoute: function (origin, destination, options) {
+            mapRoute: function (origin, destination) {
                 var dfd = $q.defer();
                 dfd.resolve({
                     bounds: {},
@@ -103,7 +103,7 @@ describe('nih.views.routing: OverviewController', function () {
         it('should ensure getMapRoute is called with origin -> geolocation, destination -> geolocation', function () {
             rootScope.$digest();
             expect(geolocation.getCurrentPosition).toHaveBeenCalled();
-            expect(MapRoute.mapRoute).toHaveBeenCalledWith(geolocationArray, geolocationArray, jasmine.any(Object));
+            expect(MapRoute.mapRoute).toHaveBeenCalledWith(geolocationArray, geolocationArray);
         });
 
         it('should fetch the graph bounds', function () {
@@ -127,7 +127,7 @@ describe('nih.views.routing: OverviewController', function () {
         it('should ensure getMapRoute is called with origin -> geolocation, destination -> stateParams', function () {
             rootScope.$digest();
             expect(geolocation.getCurrentPosition).toHaveBeenCalled();
-            expect(MapRoute.mapRoute).toHaveBeenCalledWith(geolocationArray, stateParamsArray, jasmine.any(Object));
+            expect(MapRoute.mapRoute).toHaveBeenCalledWith(geolocationArray, stateParamsArray);
         });
     });
 
@@ -147,7 +147,7 @@ describe('nih.views.routing: OverviewController', function () {
         it('should ensure getMapRoute is called with origin -> stateParams, destination -> geolocation', function () {
             rootScope.$digest();
             expect(geolocation.getCurrentPosition).toHaveBeenCalled();
-            expect(MapRoute.mapRoute).toHaveBeenCalledWith(stateParamsArray, geolocationArray, jasmine.any(Object));
+            expect(MapRoute.mapRoute).toHaveBeenCalledWith(stateParamsArray, geolocationArray);
         });
     });
 
@@ -168,7 +168,7 @@ describe('nih.views.routing: OverviewController', function () {
         it('should ensure getMapRoute is called with origin -> stateParams, destination -> stateParams', function () {
             rootScope.$digest();
             expect(geolocation.getCurrentPosition).not.toHaveBeenCalled();
-            expect(MapRoute.mapRoute).toHaveBeenCalledWith(stateParamsArray, stateParamsArray, jasmine.any(Object));
+            expect(MapRoute.mapRoute).toHaveBeenCalledWith(stateParamsArray, stateParamsArray);
         });
     });
 });


### PR DESCRIPTION
- Fixes issue where OTP request parameters were getting set in multiple places, overriding some
- Uses last plan returned from OTP (which has the lowest weight), rather than the first (which has the shortest travel time)
